### PR TITLE
Moves npm process execution to `child_process.spawn`

### DIFF
--- a/lib/get-current-npm-ls.js
+++ b/lib/get-current-npm-ls.js
@@ -9,21 +9,37 @@ var child = require('child_process');
  */
 function getCurrentNpmLs(options) {
     return new Promise(function(resolve, reject) {
-        child.exec('npm list --depth=0 --json' +
-            (options.prod ? ' --prod' : '') +
-            (options.dev ? ' --dev' : ''), {
-                cwd: options.directory
-            }, function(error, stdout, stderr) {
-            var curDeps;
+        var npm = child.spawn('npm',
+            ['list', '--depth=0', '--json', options.prod ? '--prod' : '', options.dev ? '--dev' : ''],
+            { cwd: options.directory }
+        );
+        var stdoutCollector = '';
+        var stderrCollector = ''
 
-            // if `npm` command not found
-            if (error && error.code === 127) {
-                reject(stderr);
-                return;
+        npm.stdout.on('data', function(chunk) {
+            stdoutCollector += chunk;
+        });
+
+        npm.stderr.on('data', function(chunk) {
+            stderrCollector += chunk;
+        });
+
+        npm.on('error', function(error) {
+            reject(error);
+        })
+
+        npm.on('close', function(code) {
+            try {
+                var parsedData = JSON.parse(stdoutCollector);
+                resolve(parsedData.dependencies);
+            } catch (err) {
+                if (code !== 0) {
+                    reject(stderrCollector);
+                    return;
+                }
+
+                reject(err);
             }
-
-            curDeps = JSON.parse(stdout).dependencies;
-            resolve(curDeps);
         });
     });
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "package-checker",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Library to compare currently installed versions of packages with package.json file",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Unfortunately child_process.exec method has size limit for stdout and stderr (by default it's 200kB). When limit is reached command will be interrupted, and stdout will contain incorrect JSON, that can't be parsed.
